### PR TITLE
Add useDashBoardData hook and DashboardCardData type for modular dash…

### DIFF
--- a/shared/hooks/useDashboardData.ts
+++ b/shared/hooks/useDashboardData.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react'
+//import { fetchBrandData } from '../utils/fetchBrandData'
+//import type { BrandData } from '../utils/fetchBrandData'
+import type { DashboardCardData } from '../types/dashboardCardData'
+
+type UserType = 'brand' | 'influencer'
+
+// Custom hook to load and structure dashboard data for brand/influencer users
+const useDashBoardData = (userType: UserType) => {
+	const [cards, setCards] = useState<DashboardCardData[]>([])
+	const [loading, setLoading] = useState(true)
+	const [error, setError] = useState<string | null>()
+
+	useEffect(() => {
+		const loadData = async () => {
+			try {
+				// Fetch data if the user is a brand
+				/*
+                if (userType === 'brand') {
+					const data = await fetchBrandData()
+
+					// Format the fetched data into a card-friendly array - data model not finalized yet
+					setCards([
+						{ label: 'Creator Amount', value: data.creatorAmount },
+						{ label: 'Audience Age', value: data.audienceAge },
+						{
+							label: 'Audience Gender',
+							value: data.audienceGender,
+						},
+					])
+				}
+                */
+				/* will add influencer data when ready 
+                
+                if (userType === "influencer") {
+                    const data = await fetchInfluencerData()
+                    setCards([
+                      {},
+                    ])
+                  }
+                */
+			} catch (err) {
+				setError('Failed to load data')
+			} finally {
+				setLoading(false)
+			}
+		}
+		loadData()
+	}, [userType])
+
+	// Return card data and loading state to the component
+	return { cards, loading, error }
+}
+
+export default useDashBoardData

--- a/shared/types/dashboardCardData.ts
+++ b/shared/types/dashboardCardData.ts
@@ -1,0 +1,6 @@
+// Defines the reusable shape of a dashboard card
+
+export interface DashboardCardData {
+	label: string
+	value: number | string
+}


### PR DESCRIPTION
This PR introduces the reusable hook `useDashBoardData` under `shared/hooks/`, with a `DashboardCardData` type under `shared/types/`. The hook currently consumes and formats brand dashboard data, and will later support influencer data as well.

- `useDashBoardData.ts`: wraps fetch functions and formats the results into a shared card format
- `dashboardCardData.ts`: defines a consistent type for card props across the dashboard UI

**To be implemented**
- Brand logic might be adjusted once the final API shape is confirmed
- Influencer logic will be added once the fetch function for influencer is shared
- This hook is planned to be used inside the `DashboardContainer` — open to adjustments depending on how the container shapes up.
