### PR TITLE
fix error resetting issue for influencer app

### DIFF
--- a/influencer/src/hooks/use-dashboard-data.ts
+++ b/influencer/src/hooks/use-dashboard-data.ts
@@ -21,6 +21,8 @@ const useDashboardData = (influencerId: string) => {
 
 	useEffect(() => {
 		const loadData = async () => {
+			// Reset error state from the first render
+			setError('')
 			try {
 				const data = await fetchInfluencerData(influencerId)
 


### PR DESCRIPTION
Fix the error resetting issue, which is related to the logic used in the dashboard container. (See here: 
```
const { user, isLoading: userLoading, isError: userError } = useUser()
	const influencerId = user?.id
	const { cards, loading, error } = useDashboardData(influencerId)
```
)

This PR helps the error state to be reset in the second render.