### PR TITLE
fix error resetting issue

### DIFF
--- a/influencer/src/hooks/use-dashboard-data.ts
+++ b/influencer/src/hooks/use-dashboard-data.ts
@@ -22,12 +22,11 @@ const useDashboardData = (influencerId: string) => {
 	useEffect(() => {
 		// Wait until influencerId is available before calling the fetch to avoid calling the API with an invalid ID
 		if (!influencerId) {
-			setLoading(true)
+			setLoading(false)
 			return
 		}
 
 		const loadData = async () => {
-			setLoading(true)
 			try {
 				const data = await fetchInfluencerData(influencerId)
 

--- a/influencer/src/hooks/use-dashboard-data.ts
+++ b/influencer/src/hooks/use-dashboard-data.ts
@@ -28,8 +28,6 @@ const useDashboardData = (influencerId: string) => {
 
 		const loadData = async () => {
 			setLoading(true)
-			// Reset error state from the first render
-			setError('')
 			try {
 				const data = await fetchInfluencerData(influencerId)
 

--- a/influencer/src/hooks/use-dashboard-data.ts
+++ b/influencer/src/hooks/use-dashboard-data.ts
@@ -20,7 +20,14 @@ const useDashboardData = (influencerId: string) => {
 	const [error, setError] = useState<string | null>(null)
 
 	useEffect(() => {
+		// Wait until influencerId is available before calling the fetch to avoid calling the API with an invalid ID
+		if (!influencerId) {
+			setLoading(true)
+			return
+		}
+
 		const loadData = async () => {
+			setLoading(true)
 			// Reset error state from the first render
 			setError('')
 			try {

--- a/influencer/src/hooks/use-dashboard-data.ts
+++ b/influencer/src/hooks/use-dashboard-data.ts
@@ -21,6 +21,8 @@ const useDashboardData = (influencerId: string) => {
 
 	useEffect(() => {
 		const loadData = async () => {
+			// Reset error state from the first render
+			setError('')
 			try {
 				const data = await fetchInfluencerData(influencerId)
 


### PR DESCRIPTION
Fix the error resetting issue, which is related to the logic used in the dashboard container. (See here:

```
const { user, isLoading: userLoading, isError: userError } = useUser()
	const influencerId = user?.id
	const { cards, loading, error } = useDashboardData(influencerId)
```
)

This PR helps the error state to be reset in the second render.